### PR TITLE
Add metrics collector

### DIFF
--- a/lib/pipeline/response_writer.js
+++ b/lib/pipeline/response_writer.js
@@ -1,6 +1,7 @@
 var ResponseMessage = require('../../messages').Response;
 var encoder = require('pb-stream').encoder;
 
-module.exports = function () {
+module.exports = function (metrics) {
+	metrics.increment('requests.processed');
   return encoder(ResponseMessage);
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "async": "~0.9.0",
+    "auth0-instrumentation": "github:auth0/auth0-instrumentation#v0.0.7",
     "bcrypt": "~0.8.5",
     "bunyan": "~1.3.3",
     "cb": "~0.1.0",


### PR DESCRIPTION
Collect two metrics using `auth0-instrumentation` and [DataDog](https://www.datadoghq.com/):

* Number of incoming requests
* Number of processed requests

The metrics collection will work if `env['METRICS_API_KEY']` is a valid DataDog API Key.

Screenshot:

<img width="808" alt="screen shot 2016-04-06 at 10 47 23" src="https://cloud.githubusercontent.com/assets/15843/14319272/ea80fdfe-fbe6-11e5-9820-26ff0c8aa204.png">
