### PR TITLE
Update ms dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "js-yaml": "~3.2.5",
     "lodash": "~3.1.0",
     "master-process": "~2.3.1",
-    "ms": "~0.7.1",
+    "ms": "~2.0.0",
     "pb-stream": "~1.1.0",
     "protobufjs": "~5.0.1",
     "randomstring": "~1.0.3",


### PR DESCRIPTION
The `ms` version used is flagged by snyk as vulnerable to `Regular Expression Denial of Service`. Besides there is no impact in the way we are using it, I want to get rid of the report.