### PR TITLE
Use same values for queue length reporting between DataDog and CloudWatch

### DIFF
--- a/server.js
+++ b/server.js
@@ -116,7 +116,7 @@ function BaaSServer (options) {
 util.inherits(BaaSServer, EventEmitter);
 
 BaaSServer.prototype._reportQueueLength = function () {
-  this._metrics.gauge('requests.queued', this._queue.length);
+  this._metrics.gauge('requests.queued', this._intervalQueued);
 
   const dimensions = [];
 


### PR DESCRIPTION
DataDog is reporting queue length numbers significantly smaller than CloudWatch ones in some contexts.