### PR TITLE
Timeout requests

### DIFF
--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@ const defaults = {
   hostname: '0.0.0.0',
   logLevel: 'info',
   socketTimeout: 2000,
+  workerTimeout: 1000,
   metrics: {
     gauge:     _.noop,
     increment: _.noop,
@@ -101,7 +102,8 @@ function BaaSServer (options) {
   this._workers.forEach(worker => {
     worker.on('drain', () => {
       const pending = this._queue.shift();
-      if (!pending) {
+      const timedOut = pending && ((Date.now() - pending.start) > this._config.workerTimeout);
+      if (!pending || timedOut) {
         this._workers.push(worker);
       } else {
         worker.sendRequest(pending.request, pending.done(worker.id, true));
@@ -237,7 +239,7 @@ BaaSServer.prototype._handler = function(socket) {
       if (!this._workers.length){
         this._intervalQueued++;
         // no available workers, queue and wait
-        this._queue.push({request, done});
+        this._queue.push({request, done, start});
         return callback();
       }
 

--- a/test/queue.tests.js
+++ b/test/queue.tests.js
@@ -19,7 +19,7 @@ describe('serving queueing', function () {
 
       server.start(function (err, address) {
         if (err) { return done(err); }
-        client = new BaaSClient(_.extend({}, address), done);
+        client = new BaaSClient(_.extend({requestTimeout: 500}, address), done);
       });
     });
   });
@@ -39,6 +39,16 @@ describe('serving queueing', function () {
     client.hash(password, function (err, hash) {
       if (err) { return done(err); }
       assert.ok(bcrypt.compareSync(password, hash));
+      done();
+    });
+  });
+
+  it('should timeout', function (done) {
+    const password = 'foobar';
+    server._config.workerTimeout = 10;
+    client.hash(password, _.noop);
+    client.hash(password, function (err) {
+      assert.equal(err.reason, 'timeout');
       done();
     });
   });


### PR DESCRIPTION
This change makes the BaaS server time out requests that took more than `config.workerTimeout`, which defaults to 1000 ms. Since the default client timeout is 500 ms, the requests being dropped from the queue here were already timed out (so we're just avoiding wasting computing cycles).